### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/k07g/g2/security/code-scanning/1](https://github.com/k07g/g2/security/code-scanning/1)

To fix the problem, explicitly restrict the `GITHUB_TOKEN` permissions for jobs that currently rely on inherited defaults. For `test` and `build`, the steps only need to read the repository contents, so we can safely set `permissions: contents: read`. The `push-to-ecr` job already has an appropriate `permissions` block (`id-token: write`, `contents: read`) because it needs OIDC for AWS and repo read access.

The best minimal fix is to add a `permissions` block at the workflow root so it applies to all jobs by default, and then keep the more permissive block already defined for `push-to-ecr` (job-level permissions override the workflow-level defaults). Concretely:
- In `.github/workflows/ci.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `on:` block and the `jobs:` block.  
- Leave the existing `permissions` block under `push-to-ecr` unchanged.

This documents that `test` and `build` only have read access to repo contents, while `push-to-ecr` retains the extra `id-token: write` access it requires.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
